### PR TITLE
Fix typo

### DIFF
--- a/cmd/i.go
+++ b/cmd/i.go
@@ -9,7 +9,7 @@ import (
 var iCmd = &cobra.Command{
 	Use:     "i",
 	Short:   "Launches pman in interactive mode",
-	Aliases: []string{"interactive", "iteractive"},
+	Aliases: []string{"interactive", "iterative"},
 	Run: func(cmd *cobra.Command, args []string) {
 		ui.Tui()
 	},


### PR DESCRIPTION
`iteractive` word doesn't exist.

Use iterative, as interactive is already present in the list.

I open this one aside #17 because this one should be discussed.
