### PR TITLE
Allow multiple status in `pman ls --f`

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -25,7 +26,7 @@ var lsCmd = &cobra.Command{
 		}
 		if filterFlag != "" {
 			fmt.Println("Filtering by status : ", filterFlag)
-			data = utils.FilterByStatus(data, filterFlag)
+			data = utils.FilterByStatuses(data, strings.Split(filterFlag, ","))
 		}
 		if oldUI {
 			return ui.RenderTable(data)
@@ -36,6 +37,6 @@ var lsCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(lsCmd)
-	lsCmd.Flags().String("f", "", "Filter projects by status. Usage : pman ls --f <status>")
+	lsCmd.Flags().String("f", "", "Filter projects by status. Usage : pman ls --f <status1[,status2]>")
 	lsCmd.Flags().Bool("c", false, "list projects using the colorful table. Usage : pman ls --c")
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -26,11 +26,13 @@ func TitleCase(s string) string {
 	return c.String(s)
 }
 
-func FilterByStatus(data map[string]string, status string) map[string]string {
+func FilterByStatuses(data map[string]string, status []string) map[string]string {
 	filteredData := make(map[string]string)
 	for k, v := range data {
-		if v == status {
-			filteredData[k] = v
+		for _, s := range status {
+			if v == s {
+				filteredData[k] = v
+			}
 		}
 	}
 	return filteredData


### PR DESCRIPTION
This little PR allows to filter with multiple status in `pman ls --f`, separated by a comma (if any).  
New usage: `pman ls --f <status1[,status2]>`  
Examples:
* `pman ls --f ongoing,paused`
* `pman ls --f ongoing` (old way still works)
* `pman ls --f ongoing,` (trailing comma isn't a problem)

![image](https://github.com/theredditbandit/pman/assets/10067226/290d8786-e918-483d-bbb8-e5c28c55fbe8)
