### PR TITLE
Performance improvement : `pman ls`  command is now 4x faster for most use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use "pman [command] --help" for more information about a command.
 ## How does it work
 
 ### init
-when you run `pman init .` in any directory, it will look for subdirectories that contain a README.md or a .git folder and consider it as a project directory.
+When you run `pman init .` in any directory, it will look for subdirectories that contain a README.md or a .git folder and consider it as a project directory.
 ![image](https://github.com/theredditbandit/pman/assets/85390033/b9d6fcd3-41ca-4bd2-aa32-9b3e9bff1be8)
 
 ### set, status, info and filter

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -45,7 +45,7 @@ avlpn or something smaller and use that to query pman`,
 			return err
 		}
 		lastEdit := make(map[string]string)
-		lastEdit["lastWrite"] = fmt.Sprintf(time.Now().Format("02 Jan 06 15:04"))
+		lastEdit["lastWrite"] = fmt.Sprint(time.Now().Format("02 Jan 06 15:04"))
 		err = db.WriteToDB(db.DBName, lastEdit, ConfigBucket)
 		if err != nil {
 			log.Print(err)

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -42,7 +44,13 @@ avlpn or something smaller and use that to query pman`,
 		if err != nil {
 			return err
 		}
-
+		lastEdit := make(map[string]string)
+		lastEdit["lastWrite"] = fmt.Sprintf(time.Now().Format("02 Jan 06 15:04"))
+		err = db.WriteToDB(db.DBName, lastEdit, ConfigBucket)
+		if err != nil {
+			log.Print(err)
+			return err
+		}
 		return nil
 	},
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -50,6 +52,13 @@ var delCmd = &cobra.Command{
 		}
 		err = nil
 		if err != nil {
+			return err
+		}
+		lastEdit := make(map[string]string)
+		lastEdit["lastWrite"] = fmt.Sprintf(time.Now().Format("02 Jan 06 15:04"))
+		err = db.WriteToDB(db.DBName, lastEdit, ConfigBucket)
+		if err != nil {
+			log.Print(err)
 			return err
 		}
 		fmt.Printf("Successfully deleted %s from the db \n", projName)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -55,7 +55,7 @@ var delCmd = &cobra.Command{
 			return err
 		}
 		lastEdit := make(map[string]string)
-		lastEdit["lastWrite"] = fmt.Sprintf(time.Now().Format("02 Jan 06 15:04"))
+		lastEdit["lastWrite"] = fmt.Sprint(time.Now().Format("02 Jan 06 15:04"))
 		err = db.WriteToDB(db.DBName, lastEdit, ConfigBucket)
 		if err != nil {
 			log.Print(err)

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -20,6 +20,7 @@ var lsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		filterFlag, _ := cmd.Flags().GetString("f")
 		oldUI, _ := cmd.Flags().GetBool("c")
+		refreshLastEditTime, _ := cmd.Flags().GetBool("r")
 		data, err := db.GetAllRecords(db.DBName, StatusBucket)
 		if err != nil {
 			return err
@@ -29,9 +30,9 @@ var lsCmd = &cobra.Command{
 			data = utils.FilterByStatuses(data, strings.Split(filterFlag, ","))
 		}
 		if oldUI {
-			return ui.RenderTable(data)
+			return ui.RenderTable(data, refreshLastEditTime)
 		}
-		return ui.RenderInteractiveTable(data)
+		return ui.RenderInteractiveTable(data, refreshLastEditTime)
 	},
 }
 
@@ -39,4 +40,5 @@ func init() {
 	rootCmd.AddCommand(lsCmd)
 	lsCmd.Flags().String("f", "", "Filter projects by status. Usage : pman ls --f <status1[,status2]>")
 	lsCmd.Flags().Bool("c", false, "list projects using the colorful table. Usage : pman ls --c")
+	lsCmd.Flags().Bool("r", false, "Refresh Last Edited time: pman ls --r")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ const (
 	StatusBucket       = "projects"
 	ProjectPathBucket  = "projectPaths"
 	ProjectAliasBucket = "projectAliases"
+	ConfigBucket       = "config"
 	version            = "1.0"
 )
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -51,7 +51,7 @@ var setCmd = &cobra.Command{
 		}
 
 		lastEdit := make(map[string]string)
-		lastEdit["lastWrite"] = fmt.Sprintf(time.Now().Format("02 Jan 06 15:04"))
+		lastEdit["lastWrite"] = fmt.Sprint(time.Now().Format("02 Jan 06 15:04"))
 		err = db.WriteToDB(db.DBName, lastEdit, ConfigBucket)
 		if err != nil {
 			log.Print(err)

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -47,6 +49,15 @@ var setCmd = &cobra.Command{
 			fmt.Println("Error updating record : ", err)
 			return err
 		}
+
+		lastEdit := make(map[string]string)
+		lastEdit["lastWrite"] = fmt.Sprintf(time.Now().Format("02 Jan 06 15:04"))
+		err = db.WriteToDB(db.DBName, lastEdit, ConfigBucket)
+		if err != nil {
+			log.Print(err)
+			return err
+		}
+
 		fmt.Printf("Project %s set to status %s\n", pname, status)
 		return nil
 	},

--- a/pkg/indexer.go
+++ b/pkg/indexer.go
@@ -13,6 +13,7 @@ const (
 	StatusBucket       = "projects"
 	ProjectPaths       = "projectPaths"
 	ProjectAliasBucket = "projectAliases"
+	LastUpdatedBucket  = "lastUpdated"
 )
 
 var (

--- a/pkg/indexer.go
+++ b/pkg/indexer.go
@@ -2,9 +2,11 @@ package pkg
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/theredditbandit/pman/pkg/db"
 )
@@ -14,6 +16,7 @@ const (
 	ProjectPaths       = "projectPaths"
 	ProjectAliasBucket = "projectAliases"
 	LastUpdatedBucket  = "lastUpdated"
+	ConfigBucket       = "config"
 )
 
 var (
@@ -61,6 +64,14 @@ func InitDirs(args []string) error {
 		log.Print(err)
 		return err
 	}
+	lastEdit := make(map[string]string)
+	lastEdit["lastWrite"] = fmt.Sprintf(time.Now().Format("02 Jan 06 15:04"))
+	err = db.WriteToDB(db.DBName, lastEdit, ConfigBucket)
+	if err != nil {
+		log.Print(err)
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/indexer.go
+++ b/pkg/indexer.go
@@ -65,7 +65,7 @@ func InitDirs(args []string) error {
 		return err
 	}
 	lastEdit := make(map[string]string)
-	lastEdit["lastWrite"] = fmt.Sprintf(time.Now().Format("02 Jan 06 15:04"))
+	lastEdit["lastWrite"] = fmt.Sprint(time.Now().Format("02 Jan 06 15:04"))
 	err = db.WriteToDB(db.DBName, lastEdit, ConfigBucket)
 	if err != nil {
 		log.Print(err)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/charmbracelet/glamour"
@@ -108,4 +109,24 @@ func ReadREADME(dbname, projectName string) ([]byte, error) {
 		return nil, errors.Join(ErrReadREADME, fmt.Errorf("something went wrong while reading README for %s: %w", projectName, err))
 	}
 	return data, nil
+}
+
+func UpdateLastEditedTime() error {
+	r := fmt.Sprint(time.Now().Unix())
+	rec := map[string]string{"lastRefreshTime": r}
+	err := db.WriteToDB(db.DBName, rec, pkg.ConfigBucket)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func DayPassed(t string) bool {
+	oneDay := 86400
+	now := time.Now().Unix()
+	recTime, _ := strconv.ParseInt(t, 10, 64)
+	if now-recTime > int64(oneDay) {
+		return true
+	}
+	return false
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -125,8 +125,5 @@ func DayPassed(t string) bool {
 	oneDay := 86400
 	now := time.Now().Unix()
 	recTime, _ := strconv.ParseInt(t, 10, 64)
-	if now-recTime > int64(oneDay) {
-		return true
-	}
-	return false
+	return now-recTime > int64(oneDay)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -101,6 +101,11 @@ func ReadREADME(dbname, projectName string) ([]byte, error) {
 		}
 	}
 	pPath := filepath.Join(path, "README.md")
+	_, err = os.Stat(pPath)
+	if os.IsNotExist(err) {
+		msg := fmt.Sprintf("# README does not exist for %s", projectName)
+		return []byte(msg), nil
+	}
 	data, err := os.ReadFile(pPath)
 	if err != nil {
 		return nil, errors.Join(ErrReadREADME, fmt.Errorf("something went wrong while reading README for %s: %w", projectName, err))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,9 +42,7 @@ func FilterByStatuses(data map[string]string, status []string) map[string]string
 
 func GetLastModifiedTime(dbname, pname string) string {
 	var lastModTime time.Time
-	var lastModFile string
 	today := time.Now()
-	_ = lastModFile
 	pPath, err := db.GetRecord(dbname, pname, pkg.ProjectPaths)
 	if err != nil {
 		return "Something went wrong"
@@ -55,7 +53,6 @@ func GetLastModifiedTime(dbname, pname string) string {
 		}
 		if !info.IsDir() && info.ModTime().After(lastModTime) {
 			lastModTime = info.ModTime()
-			lastModFile = info.Name()
 		}
 		return nil
 	})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -181,7 +182,7 @@ func Test_ReadREADME(t *testing.T) {
 	})
 
 	t.Run("Test ReadREADME with invalid README file name", func(t *testing.T) {
-		expected := []byte(nil)
+		expected := []byte(fmt.Sprintf("# README does not exist for %s", projectName))
 
 		t.Cleanup(func() {
 			err := db.DeleteDb(dbname)
@@ -201,7 +202,7 @@ func Test_ReadREADME(t *testing.T) {
 		actual, err := utils.ReadREADME(dbname, projectName)
 
 		assert.Equal(t, expected, actual)
-		require.ErrorIs(t, err, utils.ErrReadREADME)
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
This is achieved by only indexing all the projects for `Last Edited` value once a day. and then those values are the same for 24 hours.

the value of `Last Edited` time can be updated to have the most recent value using `pman ls --r` which refreshes the db with current values.