### PR TITLE
update `GetLastModifiedTime` function and corresponding tests

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -17,6 +17,7 @@ var lsCmd = &cobra.Command{
 	Long: `List all indexed projects along with their status
     Usage : pman ls
     `,
+	Aliases: []string{"l"},
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		filterFlag, _ := cmd.Flags().GetString("f")
 		refreshLastEditTime, _ := cmd.Flags().GetBool("r")

--- a/pkg/ui/interactiveTable.go
+++ b/pkg/ui/interactiveTable.go
@@ -95,7 +95,8 @@ func RenderInteractiveTable(data map[string]string, refreshLastEditedTime bool) 
 	for proj, status := range data {
 		alias, err := db.GetRecord(db.DBName, proj, pkg.ProjectAliasBucket)
 		if refreshLastEditedTime {
-			lastEdited, timestamp = utils.GetLastModifiedTime(db.DBName, proj)
+			t := utils.GetLastModifiedTime(db.DBName, proj)
+			lastEdited, timestamp = utils.ParseTime(t)
 			rec := map[string]string{proj: fmt.Sprintf("%s-%d", lastEdited, timestamp)}
 			err := db.WriteToDB(db.DBName, rec, pkg.LastUpdatedBucket)
 			if err != nil {

--- a/pkg/ui/statusTable.go
+++ b/pkg/ui/statusTable.go
@@ -47,7 +47,8 @@ func RenderTable(data map[string]string, refreshLastEditedTime bool) error {
 	for p, status := range data {
 		alias, err := db.GetRecord(db.DBName, p, pkg.ProjectAliasBucket)
 		if refreshLastEditedTime {
-			lastEdited, timestamp = utils.GetLastModifiedTime(db.DBName, p)
+			t := utils.GetLastModifiedTime(db.DBName, p)
+			lastEdited, timestamp = utils.ParseTime(t)
 			rec := map[string]string{p: fmt.Sprintf("%s-%d", lastEdited, timestamp)}
 			err := db.WriteToDB(db.DBName, rec, pkg.LastUpdatedBucket)
 			if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -41,13 +41,12 @@ func FilterByStatuses(data map[string]string, status []string) map[string]string
 	return filteredData
 }
 
-// GetLastModifiedTime returns the last modified time and the unix timestamp as well that is used to sort the projects later
-func GetLastModifiedTime(dbname, pname string) (string, int64) {
+// GetLastModifiedTime returns the last modified time
+func GetLastModifiedTime(dbname, pname string) string {
 	var lastModTime time.Time
-	today := time.Now()
 	pPath, err := db.GetRecord(dbname, pname, pkg.ProjectPaths)
 	if err != nil {
-		return "Something went wrong", 0
+		return "Something went wrong"
 	}
 	_ = filepath.Walk(pPath, func(_ string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -58,14 +57,7 @@ func GetLastModifiedTime(dbname, pname string) (string, int64) {
 		}
 		return nil
 	})
-
-	switch fmt.Sprint(lastModTime.Date()) {
-	case fmt.Sprint(today.Date()):
-		return fmt.Sprintf("Today %s", lastModTime.Format("15:04")), int64(lastModTime.Unix())
-	case fmt.Sprint(today.AddDate(0, 0, -1).Date()):
-		return fmt.Sprintf("Yesterday %s", lastModTime.Format("17:00")), int64(lastModTime.Unix())
-	}
-	return fmt.Sprint(lastModTime.Format("02 Jan 06 15:04")), int64(lastModTime.Unix())
+	return fmt.Sprint(lastModTime.Format("02 Jan 06 15:04"))
 }
 
 // BeautifyMD: returns styled markdown
@@ -127,4 +119,21 @@ func DayPassed(t string) bool {
 	now := time.Now().Unix()
 	recTime, _ := strconv.ParseInt(t, 10, 64)
 	return now-recTime > int64(oneDay)
+}
+
+func ParseTime(tstr string) (string, int64) {
+	layout := "02 Jan 06 15:04"
+	p, err := time.Parse(layout, tstr)
+	timeStamp := p.Unix()
+	if err != nil {
+		return "unnkown", 0
+	}
+	today := time.Now()
+	switch fmt.Sprint(p.Date()) {
+	case fmt.Sprint(today.Date()):
+		return fmt.Sprintf("Today %s", p.Format("15:04")), timeStamp
+	case fmt.Sprint(today.AddDate(0, 0, -1).Date()):
+		return fmt.Sprintf("Yesterday %s", p.Format("17:00")), timeStamp
+	}
+	return tstr, timeStamp
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -218,15 +218,19 @@ func Test_GetLastModifiedTime(t *testing.T) {
 		require.NoError(t, err)
 		f, err := os.Create(projectPath + "/README.md")
 		require.NoError(t, err)
+		fCreateTime := time.Now()
+		correctModTime := fCreateTime.Format("02 Jan 06 15:04")
+		err = os.Chtimes(projectPath+"/README.md", fCreateTime, fCreateTime)
+		require.NoError(t, err)
 		f.Close()
 
 		err = db.WriteToDB(dbname, map[string]string{projectName: projectPath}, pkg.ProjectPaths)
 		require.NoError(t, err)
 
-		actual, _ := utils.GetLastModifiedTime(dbname, projectName)
+		actual := utils.GetLastModifiedTime(dbname, projectName)
 
 		assert.NotEqual(t, expectedMsg, actual)
-		assert.Contains(t, actual, "Today")
+		assert.Equal(t, correctModTime, actual)
 		assert.NotEmpty(t, actual)
 	})
 
@@ -241,17 +245,19 @@ func Test_GetLastModifiedTime(t *testing.T) {
 		require.NoError(t, err)
 		f, err := os.Create(projectPath + "/README.md")
 		require.NoError(t, err)
-		err = os.Chtimes(projectPath+"/README.md", time.Now().AddDate(0, 0, -1), time.Now().AddDate(0, 0, -1))
+		fCreateTime := time.Now().AddDate(0, 0, -1)
+		correctModTime := fCreateTime.Format("02 Jan 06 15:04")
+		err = os.Chtimes(projectPath+"/README.md", fCreateTime, fCreateTime)
 		require.NoError(t, err)
 		f.Close()
 
 		err = db.WriteToDB(dbname, map[string]string{projectName: projectPath}, pkg.ProjectPaths)
 		require.NoError(t, err)
 
-		actual, _ := utils.GetLastModifiedTime(dbname, projectName)
+		actual := utils.GetLastModifiedTime(dbname, projectName)
 
 		assert.NotEqual(t, expectedMsg, actual)
-		assert.Contains(t, actual, "Yesterday")
+		assert.Equal(t, correctModTime, actual)
 		assert.NotEmpty(t, actual)
 	})
 	t.Run("Test GetLastModifiedTime under normal conditions: case old modification", func(t *testing.T) {
@@ -272,7 +278,7 @@ func Test_GetLastModifiedTime(t *testing.T) {
 		err = db.WriteToDB(dbname, map[string]string{projectName: projectPath}, pkg.ProjectPaths)
 		require.NoError(t, err)
 
-		actual, _ := utils.GetLastModifiedTime(dbname, projectName)
+		actual := utils.GetLastModifiedTime(dbname, projectName)
 
 		assert.NotEqual(t, expectedMsg, actual)
 		assert.NotEmpty(t, actual)
@@ -280,7 +286,7 @@ func Test_GetLastModifiedTime(t *testing.T) {
 	t.Run("Test GetLastModifiedTime with invalid project", func(t *testing.T) {
 		projectPath := "./invalid_project"
 
-		actual, _ := utils.GetLastModifiedTime(dbname, projectPath)
+		actual := utils.GetLastModifiedTime(dbname, projectPath)
 
 		assert.Equal(t, expectedMsg, actual)
 	})


### PR DESCRIPTION
as recommended by @ccoVeille in #42 , `GetLastModifiedTime` now only returns the time string , and everything else is now handled in a separate `ParseTime` function.